### PR TITLE
修正在 python3 下无法工作的问题

### DIFF
--- a/README
+++ b/README
@@ -17,4 +17,5 @@ Linux & Mac
 * run prepare.sh
 * run any script to generate model
 * convert.sh MODEL_PATH to convert model to TFJS format
-* python -m SimpleHTTPServer
+* python -m SimpleHTTPServer(python2)
+* python -m http.server(python3)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 tensorflowjs>=0.3.1
-tensorflow==1.7.0
+tensorflow>=1.7.0
 jupyter>=1.0.0
-h5py>=2.7
+h5py==2.8


### PR DESCRIPTION
修正版本号
在python3中
SimpleHTTPServer被废弃 
使用http.server代替